### PR TITLE
Match Foundation semantics for superEncoder/Decoder()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.5.0-bionic as build
+FROM swift:5.5.0-focal as build
 WORKDIR /build
 
 # First just resolve dependencies.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -20,9 +20,9 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "IkigaJSON",
-            dependencies: ["NIO"]),
+            dependencies: [.product(name: "NIO", package: "swift-nio")]),
         .testTarget(
             name: "IkigaJSONTests",
-            dependencies: ["IkigaJSON"]),
+            dependencies: [.target(name: "IkigaJSON")]),
     ]
 )

--- a/Sources/IkigaJSON/Codable/JSONDecoder.swift
+++ b/Sources/IkigaJSON/Codable/JSONDecoder.swift
@@ -524,7 +524,6 @@ fileprivate struct UnkeyedJSONDecodingContainer: UnkeyedDecodingContainer {
     mutating func decode(_ type: Bool.Type) throws -> Bool {
         try assertHasMore()
         let type = decoder.description.type(atOffset: offset)
-        decoder.description.skipIndex(atOffset: &offset)
         skipValue()
         
         switch type {

--- a/Sources/IkigaJSON/Codable/JSONDecoder.swift
+++ b/Sources/IkigaJSON/Codable/JSONDecoder.swift
@@ -25,6 +25,9 @@ func date(from string: String) throws -> Date {
     }
 }
 
+/// Used by `KeyedDecodingContainer.superDecoder()` and `KeyedEncodingContainer.superEncoder()`.
+internal enum SuperCodingKey: String, CodingKey { case `super` }
+
 /// These settings can be used to alter the decoding process.
 public struct JSONDecoderSettings {
     public init() {}
@@ -435,53 +438,39 @@ fileprivate struct KeyedJSONDecodingContainer<Key: CodingKey>: KeyedDecodingCont
         return try decodeInt(type, forKey: key)
     }
     
-    func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
+    private func subDecoder<Key: CodingKey>(forKey key: Key, orThrow failureError: Error, appendingToPath: Bool = true) throws -> _JSONDecoder {
         guard let (_, offset) = self.decoder.description.valueOffset(
             forKey: self.decoder.string(forKey: key),
             convertingSnakeCasing: self.decoder.snakeCasing,
             in: self.decoder.pointer
         ) else {
-            throw JSONParserError.decodingError(expected: type, keyPath: codingPath)
+            throw failureError
         }
-        
-        let decoder = self.decoder.subDecoder(offsetBy: offset)
-        return try decoder.decode(type)
+        return self.decoder.subDecoder(offsetBy: offset)
+    }
+    
+    func decode<T>(_: T.Type, forKey key: Key) throws -> T where T : Decodable {
+        return try self.subDecoder(
+            forKey: key,
+            orThrow: JSONParserError.decodingError(expected: T.self, keyPath: self.codingPath),
+            appendingToPath: false
+        ).decode(T.self)
     }
     
     func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
-        guard let (_, offset) = self.decoder.description.valueOffset(
-            forKey: self.decoder.string(forKey: key),
-            convertingSnakeCasing: self.decoder.snakeCasing,
-            in: self.decoder.pointer
-        ) else {
-            throw JSONParserError.missingKeyedContainer
-        }
-        
-        var decoder = self.decoder.subDecoder(offsetBy: offset)
-        decoder.codingPath.append(key)
-        return try decoder.container(keyedBy: NestedKey.self)
+        return try self.subDecoder(forKey: key, orThrow: JSONParserError.missingKeyedContainer).container(keyedBy: NestedKey.self)
     }
     
     func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
-        guard let (_, offset) = self.decoder.description.valueOffset(
-            forKey: self.decoder.string(forKey: key),
-            convertingSnakeCasing: self.decoder.snakeCasing,
-            in: self.decoder.pointer
-        ) else {
-            throw JSONParserError.missingUnkeyedContainer
-        }
-        
-        var decoder = self.decoder.subDecoder(offsetBy: offset)
-        decoder.codingPath.append(key)
-        return try decoder.unkeyedContainer()
+        return try self.subDecoder(forKey: key, orThrow: JSONParserError.missingUnkeyedContainer).unkeyedContainer()
     }
     
     func superDecoder() throws -> Decoder {
-        return decoder
+        return try self.subDecoder(forKey: SuperCodingKey.super, orThrow: JSONParserError.missingSuperDecoder)
     }
     
     func superDecoder(forKey key: Key) throws -> Decoder {
-        return decoder
+        return try self.subDecoder(forKey: key, orThrow: JSONParserError.missingSuperDecoder)
     }
 }
 
@@ -690,6 +679,8 @@ fileprivate struct UnkeyedJSONDecodingContainer: UnkeyedDecodingContainer {
     }
     
     mutating func superDecoder() throws -> Decoder {
+        let decoder = self.decoder.subDecoder(offsetBy: offset)
+        skipValue()
         return decoder
     }
 }

--- a/Sources/IkigaJSON/Codable/JSONEncoder.swift
+++ b/Sources/IkigaJSON/Codable/JSONEncoder.swift
@@ -697,29 +697,28 @@ fileprivate struct KeyedJSONEncodingContainer<Key: CodingKey>: KeyedEncodingCont
         }
     }
     
-    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        self.encoder.writeKey(key.stringValue)
-        let encoder = _JSONEncoder(codingPath: codingPath, userInfo: self.encoder.userInfo, data: self.encoder.data)
-        return encoder.container(keyedBy: keyType)
+    mutating func nestedContainer<NestedKey>(keyedBy _: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        return self.superEncoder(forKey: key).container(keyedBy: NestedKey.self)
     }
     
     mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
-        self.encoder.writeKey(key.stringValue)
-        let encoder = _JSONEncoder(codingPath: codingPath + [key], userInfo: self.encoder.userInfo, data: self.encoder.data)
-        return encoder.unkeyedContainer()
+        return self.superEncoder(forKey: key).unkeyedContainer()
     }
     
     mutating func superEncoder() -> Encoder {
-        return encoder
+        self.encoder.writeKey(SuperCodingKey.super.stringValue)
+        return _JSONEncoder(codingPath: codingPath + [SuperCodingKey.super], userInfo: self.encoder.userInfo, data: self.encoder.data)
     }
     
     mutating func superEncoder(forKey key: Key) -> Encoder {
-        return encoder
+        self.encoder.writeKey(key.stringValue)
+        return _JSONEncoder(codingPath: codingPath + [key], userInfo: self.encoder.userInfo, data: self.encoder.data)
     }
 }
 
 fileprivate struct SingleValueJSONEncodingContainer: SingleValueEncodingContainer {
     let encoder: _JSONEncoder
+    
     var codingPath: [CodingKey] {
         return encoder.codingPath
     }
@@ -903,19 +902,16 @@ fileprivate struct UnkeyedJSONEncodingContainer: UnkeyedEncodingContainer {
         }
     }
     
-    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        self.encoder.writeComma()
-        let encoder = _JSONEncoder(codingPath: codingPath, userInfo: self.encoder.userInfo, data: self.encoder.data)
-        return encoder.container(keyedBy: keyType)
+    mutating func nestedContainer<NestedKey>(keyedBy _: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        return self.superEncoder().container(keyedBy: NestedKey.self)
     }
     
     mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
-        self.encoder.writeComma()
-        let encoder = _JSONEncoder(codingPath: codingPath, userInfo: self.encoder.userInfo, data: self.encoder.data)
-        return encoder.unkeyedContainer()
+        return self.superEncoder().unkeyedContainer()
     }
     
     mutating func superEncoder() -> Encoder {
-        return encoder
+        self.encoder.writeComma()
+        return _JSONEncoder(codingPath: codingPath, userInfo: self.encoder.userInfo, data: self.encoder.data)
     }
 }

--- a/Sources/IkigaJSON/Errors.swift
+++ b/Sources/IkigaJSON/Errors.swift
@@ -17,6 +17,7 @@ public enum JSONParserError: Error {
     case unknownJSONStrategy
     case missingKeyedContainer
     case missingUnkeyedContainer
+    case missingSuperDecoder
     case decodingError(expected: Any.Type, keyPath: [CodingKey])
     case invalidTopLevelObject
     case missingData, invalidLiteral

--- a/Tests/IkigaJSONTests/JSONTests.swift
+++ b/Tests/IkigaJSONTests/JSONTests.swift
@@ -1291,4 +1291,50 @@ final class IkigaJSONTests: XCTestCase {
         
     }
     
+    struct NestedByUsingSuper: Codable {
+        struct NestedWithinUsingSuper: Codable, Equatable { let bar: String }
+
+        private enum CodingKeys: String, CodingKey { case foo, parent, unkeyed }
+
+        let foo: Int, `super`: NestedWithinUsingSuper, parent: NestedWithinUsingSuper
+        let unkeyed: (Bool, NestedWithinUsingSuper)
+        
+        init(foo: Int, barSuper: String, barParent: String, flag: Bool, barNumbered: String) {
+            self.foo = foo
+            self.super = .init(bar: barSuper)
+            self.parent = .init(bar: barParent)
+            self.unkeyed = (flag, .init(bar: barNumbered))
+        }
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.foo = try container.decode(Int.self, forKey: .foo)
+            self.super = try .init(from: container.superDecoder())
+            self.parent = try .init(from: container.superDecoder(forKey: .parent))
+            var unkeyedContainer = try container.nestedUnkeyedContainer(forKey: .unkeyed)
+            self.unkeyed = try (unkeyedContainer.decode(Bool.self), .init(from: unkeyedContainer.superDecoder()))
+        }
+        
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(self.foo, forKey: .foo)
+            try self.super.encode(to: container.superEncoder())
+            try self.parent.encode(to: container.superEncoder(forKey: .parent))
+            var unkeyedContainer = container.nestedUnkeyedContainer(forKey: .unkeyed)
+            try unkeyedContainer.encode(self.unkeyed.0)
+            try self.unkeyed.1.encode(to: unkeyedContainer.superEncoder())
+        }
+    }
+    
+    func testSuperEncoderDecoderUsage() throws {
+        let raw = NestedByUsingSuper(foo: 5, barSuper: "super bar", barParent: "parent bar", flag: true, barNumbered: "number your days")
+        let encoded = try IkigaJSONEncoder().encode(raw)
+        let decoded = try IkigaJSONDecoder().decode(NestedByUsingSuper.self, from: encoded)
+        
+        XCTAssertEqual(raw.foo, decoded.foo)
+        XCTAssertEqual(raw.super, decoded.super)
+        XCTAssertEqual(raw.parent, decoded.parent)
+        XCTAssertEqual(raw.unkeyed.0, decoded.unkeyed.0)
+        XCTAssertEqual(raw.unkeyed.1, decoded.unkeyed.1)
+    }
 }

--- a/Tests/IkigaJSONTests/JSONTests.swift
+++ b/Tests/IkigaJSONTests/JSONTests.swift
@@ -1291,11 +1291,4 @@ final class IkigaJSONTests: XCTestCase {
         
     }
     
-    static var allTests = [
-        ("testObject", testObject),
-        ("testArray", testArray),
-        ("testEscaping", testEscaping),
-        ("testNumerical", testNumerical),
-        ("testCodablePerformance", testCodablePerformance),
-    ]
 }

--- a/Tests/IkigaJSONTests/XCTestManifests.swift
+++ b/Tests/IkigaJSONTests/XCTestManifests.swift
@@ -1,1 +1,0 @@
-import XCTest

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,0 @@
-import XCTest
-
-import IkigaJSONTests
-


### PR DESCRIPTION
See commit log for details.

Also fixes an assertion failure when decoding `Bool` values from unkeyed containers.