### PR TITLE
Don't omit output of empty array value when doing `keyedContainer.encodeIfPresent([], forKey: ...)` 

### DIFF
--- a/Sources/IkigaJSON/Codable/JSONEncoder.swift
+++ b/Sources/IkigaJSON/Codable/JSONEncoder.swift
@@ -623,8 +623,10 @@ fileprivate struct SingleValueJSONEncodingContainer: SingleValueEncodingContaine
         
         let encoder = _JSONEncoder(codingPath: codingPath, userInfo: self.encoder.userInfo, data: self.encoder.data)
         encoder.didWriteValue = self.encoder.didWriteValue
+        encoder.didHaveContainers = self.encoder.didHaveContainers
         try value.encode(to: encoder)
         self.encoder.didWriteValue = encoder.didWriteValue
+        self.encoder.didHaveContainers = encoder.didHaveContainers
     }
 }
 


### PR DESCRIPTION
Forwarding the `didWriteValue` flag but not the `didHaveContainers` flag to and from the subencoder of single-value container causes encoding an empty array to be incorrectly treated as having encoded nothing and thus not showing up in the output at all.