### PR TITLE
Fixed issue with case .formatted of DateFormatter on Linux (swift 6)

### DIFF
--- a/Sources/IkigaJSON/Codable/JSONDecoder.swift
+++ b/Sources/IkigaJSON/Codable/JSONDecoder.swift
@@ -262,6 +262,7 @@ fileprivate struct _JSONDecoder: Decoder {
                 let string = try singleValueContainer().decode(String.self)
                 
                 return try date(from: string) as! D
+            #if !canImport(FoundationEssentials) || swift(<5.10)
             case .formatted(let formatter):
                 let string = try singleValueContainer().decode(String.self)
                 
@@ -270,6 +271,7 @@ fileprivate struct _JSONDecoder: Decoder {
                 }
                 
                 return date as! D
+            #endif
             case .custom(let makeDate):
                 return try makeDate(self) as! D
             @unknown default:

--- a/Sources/IkigaJSON/Codable/JSONEncoder.swift
+++ b/Sources/IkigaJSON/Codable/JSONEncoder.swift
@@ -386,12 +386,14 @@ fileprivate final class _JSONEncoder: Encoder {
                 
                 key.map { writeKey($0) }
                 writeValue(string)
+            #if !canImport(FoundationEssentials) || swift(<5.10)
             case .formatted(let formatter):
                 let string = formatter.string(from: date)
                 if let key = key {
                     writeKey(key)
                 }
                 writeValue(string)
+            #endif
             case .custom(let custom):
                 let offsetBeforeKey = offset, hadWrittenValue = didWriteValue
                 if let key = key {


### PR DESCRIPTION
Just fixing the repo based on this issue at the moment on Linux: https://github.com/mattpolzin/OpenAPIReflection/pull/8