### PR TITLE
Expose IkigaJSONCore to Swift 6.2+

### DIFF
--- a/Package@swift-6.2.3.swift
+++ b/Package@swift-6.2.3.swift
@@ -20,7 +20,11 @@ let package = Package(
     .library(
       name: "IkigaJSON",
       targets: ["IkigaJSON"]
-    )
+    ),
+    .library(
+      name: "IkigaJSONCore",
+      targets: ["_JSONCore"]
+    ),
   ],
   traits: [
     .default(enabledTraits: ["ByteBufferSupport", "FoundationSupport"]),


### PR DESCRIPTION
## Summary

- expose the existing `_JSONCore` target as the `IkigaJSONCore` product in `Package@swift-6.2.3.swift`
- keep the version-specific manifest consistent with the base `Package.swift`

Swift 6.2+ selects the version-specific manifest, which currently makes the core product unavailable even though its target remains present. No target or source behavior changes.

Validated with a Swift 6.3 external consumer selecting `IkigaJSONCore` and importing `_JSONCore`, plus an Embedded Swift `riscv32-none-none-eabi` compile/link probe.

Closes #63